### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,7 +13,7 @@ IoAbstractionRef	KEYWORD1
 SwitchInput	KEYWORD1
 EepromAbstraction	KEYWORD1
 I2cAt24Eeprom	KEYWORD1
-NoEeprom		KEYWORD1
+NoEeprom	KEYWORD1
 AvrEeprom	KEYWORD1
 
 #######################################
@@ -42,8 +42,8 @@ addInterrupt	KEYWORD2
 setInterruptCallback	KEYWORD2
 cancelTask	KEYWORD2
 runLoop	KEYWORD2
-readPort    KEYWORD2
-writePort   KEYWORD2
+readPort	KEYWORD2
+writePort	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords