### PR TITLE
Update SwitchInput.cpp: inconsistent rotary upper/lower limit behaviour

### DIFF
--- a/src/SwitchInput.cpp
+++ b/src/SwitchInput.cpp
@@ -207,8 +207,10 @@ void RotaryEncoder::changePrecision(uint16_t maxValue, int currentValue) {
 
 void RotaryEncoder::increment(int8_t incVal) {
 	if(incVal >= 0) {
-		currentReading = min((uint16_t)(currentReading + incVal), maximumValue);
-		callback(currentReading);
+		if(currentReading + incVal <= maximumValue) {
+			currentReading = min((uint16_t)(currentReading + incVal), maximumValue);
+			callback(currentReading);
+		}
 	}
 	else if(currentReading != 0 && currentReading < abs(incVal)) {
 		currentReading = 0;


### PR DESCRIPTION
If you turn a rotary encoder and reach the lower limit (0) the callback function isn't being called again if you turn the encoder further. At the upper limit, the callback function is repeatedly called.
The change requested would remove this inconsistency.