### PR TITLE
Update ESP32AnalogDevice.cpp for ADC_WIDTH_BIT ESP32-S2 compatibility

### DIFF
--- a/src/esp32/ESP32AnalogDevice.cpp
+++ b/src/esp32/ESP32AnalogDevice.cpp
@@ -68,7 +68,7 @@ uint16_t EspAnalogInputMode::getCurrentReading() {
     else {
         int adcVal;
         adc2_config_channel_atten(static_cast<adc2_channel_t>(adcChannelNum), static_cast<adc_atten_t>(attenuation));
-        if(adc2_get_raw(static_cast<adc2_channel_t>(adcChannelNum), ADC_WIDTH_BIT_12, &adcVal) == ESP_OK) {
+        if(adc2_get_raw(static_cast<adc2_channel_t>(adcChannelNum), ADC_WIDTH_BIT_DEFAULT, &adcVal) == ESP_OK) {
             lastCached = adcVal;
             return adcVal;
         }
@@ -107,7 +107,7 @@ void EspAnalogOutputMode::write(unsigned int newVal) const {
 ESP32AnalogDevice* ESP32AnalogDevice::theInstance = nullptr;
 
 ESP32AnalogDevice::ESP32AnalogDevice() {
-    adc1_config_width(ADC_WIDTH_BIT_12);
+    adc1_config_width(ADC_WIDTH_BIT_DEFAULT);
 }
 
 void ESP32AnalogDevice::initPin(pinid_t pin, AnalogDirection direction) {


### PR DESCRIPTION
ADC_WIDTH_BIT_DEFAULT for at least ESP32-S2 compatibility. 
ADC_WIDTH_BIT_12 for ESP32
ADC_WIDTH_BIT_13 for ESP32-S2
instead of IFDEF, we can use  ADC_WIDTH_BIT_DEFAULT