### PR TITLE
Add all known Arduino-mbed targets to PlatformDetermination.h

### DIFF
--- a/src/PlatformDetermination.h
+++ b/src/PlatformDetermination.h
@@ -15,7 +15,7 @@
 // This file is shared across IoTaskManager and IoAbstraction
 
 // list of devices is pulled from https://github.com/arduino/ArduinoCore-mbed/blob/master/full.variables
-// set IOA_FORCE_ARDUINO_MBED to force IoAbstraction to use Arduino-mbed mode.
+// set TMIOA_FORCE_ARDUINO_MBED to force IoAbstraction to use Arduino-mbed mode.
 #if defined(ARDUINO_NANO_RP2040_CONNECT) || \
     defined(ARDUINO_ARDUINO_NANO33BLE) || \
     defined(ARDUINO_RASPBERRY_PI_PICO) || \
@@ -24,7 +24,7 @@
     defined(ARDUINO_EDGE_CONTROL) || \
     defined(ARDUINO_NICLA) || \
     defined(ARDUINO_NICLA_VISION) || \
-    defined(IOA_FORCE_ARDUINO_MBED)
+    defined(TMIOA_FORCE_ARDUINO_MBED)
 // here we're in a hybrid of mbed and Arduino basically. We treat all abstractions as Arduino though.
 #include <Arduino.h>
 # define IOA_USE_ARDUINO

--- a/src/PlatformDetermination.h
+++ b/src/PlatformDetermination.h
@@ -14,7 +14,17 @@
 // If you have a board that's not properly mapped, please raise an issue and we'll see if it's possible to add it.
 // This file is shared across IoTaskManager and IoAbstraction
 
-#if defined(ARDUINO_ARDUINO_NANO33BLE)
+// list of devices is pulled from https://github.com/arduino/ArduinoCore-mbed/blob/master/full.variables
+// set IOA_FORCE_ARDUINO_MBED to force IoAbstraction to use Arduino-mbed mode.
+#if defined(ARDUINO_NANO_RP2040_CONNECT) || \
+    defined(ARDUINO_ARDUINO_NANO33BLE) || \
+    defined(ARDUINO_RASPBERRY_PI_PICO) || \
+    defined(ARDUINO_PORTENTA_H7_M7) || \
+    defined(ARDUINO_PORTENTA_H7_M4) || \
+    defined(ARDUINO_EDGE_CONTROL) || \
+    defined(ARDUINO_NICLA) || \
+    defined(ARDUINO_NICLA_VISION) || \
+    defined(IOA_FORCE_ARDUINO_MBED)
 // here we're in a hybrid of mbed and Arduino basically. We treat all abstractions as Arduino though.
 #include <Arduino.h>
 # define IOA_USE_ARDUINO


### PR DESCRIPTION
This should make sure it compiles without forcing -DARDUINO_ARDUINO_NANO33BLE on boards that are using Arduino-mbed but are not Nano33BLE.

For unknown Arduino-mbed-based boards one can use -DTMIOA_FORCE_ARDUINO_MBED to force enable Arduino-mbed support.