### PR TITLE
Update deprecated ADC_ATTEN_DB_11 reference

### DIFF
--- a/src/esp32/ESP32AnalogDevice.cpp
+++ b/src/esp32/ESP32AnalogDevice.cpp
@@ -19,7 +19,7 @@
 
 #include <AnalogDeviceAbstraction.h>
 
-EspAnalogInputMode::EspAnalogInputMode(pinid_t pin) : onAdc1(false), adcChannelNum(0xff), pin(pin), attenuation(ADC_ATTEN_DB_11) {}
+EspAnalogInputMode::EspAnalogInputMode(pinid_t pin) : onAdc1(false), adcChannelNum(0xff), pin(pin), attenuation(ADC_ATTEN_DB_12) {}
 
 EspAnalogInputMode::EspAnalogInputMode(const EspAnalogInputMode& other) = default;
 
@@ -49,7 +49,7 @@ void EspAnalogInputMode::pinSetup() {
     // there's a chance that this GPIO may have previously been registered as output, we should
     // ensure that it's initialised as input with no pull up/down.
     if(adcChannelNum != 0xff) {
-        alterPinAttenuation(ADC_ATTEN_DB_11);
+        alterPinAttenuation(ADC_ATTEN_DB_12);
         gpio_config_t config;
         config.intr_type = GPIO_INTR_DISABLE;
         config.mode = GPIO_MODE_INPUT;


### PR DESCRIPTION
When building with PlatformIO, I get the following warning pasted below. I have changed references to `ADC_ATTEN_DB_11` to `ADC_ATTEN_DB_12` to update the deprecation warnings.

```
.pio/libdeps/esp32dev/IoAbstraction/src/esp32/ESP32AnalogDevice.cpp: In constructor 'EspAnalogInputMode::EspAnalogInputMode(pinid_t)':
.pio/libdeps/esp32dev/IoAbstraction/src/esp32/ESP32AnalogDevice.cpp:22:113: warning: 'ADC_ATTEN_DB_11' is deprecated [-Wdeprecated-declarations]
 EspAnalogInputMode::EspAnalogInputMode(pinid_t pin) : onAdc1(false), adcChannelNum(0xff), pin(pin), attenuation(ADC_ATTEN_DB_11) {}
                                                                                                                 ^~~~~~~~~~~~~~~
In file included from /Users/haleynelson/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32/include/driver/include/driver/adc.h:14,
                 from .pio/libdeps/esp32dev/IoAbstraction/src/esp32/ESP32AnalogDevice.h:11,
                 from .pio/libdeps/esp32dev/IoAbstraction/src/AnalogDeviceAbstraction.h:89,
                 from .pio/libdeps/esp32dev/IoAbstraction/src/esp32/ESP32AnalogDevice.cpp:6:
/Users/haleynelson/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32/include/hal/include/hal/adc_types.h:54:5: note: declared here
     ADC_ATTEN_DB_11 __attribute__((deprecated)) = ADC_ATTEN_DB_12,  ///<This is deprecated, it behaves the same as `ADC_ATTEN_DB_12`
     ^~~~~~~~~~~~~~~
.pio/libdeps/esp32dev/IoAbstraction/src/esp32/ESP32AnalogDevice.cpp: In member function 'void EspAnalogInputMode::pinSetup()':
.pio/libdeps/esp32dev/IoAbstraction/src/esp32/ESP32AnalogDevice.cpp:52:29: warning: 'ADC_ATTEN_DB_11' is deprecated [-Wdeprecated-declarations]
         alterPinAttenuation(ADC_ATTEN_DB_11);
                             ^~~~~~~~~~~~~~~
In file included from /Users/haleynelson/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32/include/driver/include/driver/adc.h:14,
                 from .pio/libdeps/esp32dev/IoAbstraction/src/esp32/ESP32AnalogDevice.h:11,
                 from .pio/libdeps/esp32dev/IoAbstraction/src/AnalogDeviceAbstraction.h:89,
                 from .pio/libdeps/esp32dev/IoAbstraction/src/esp32/ESP32AnalogDevice.cpp:6:
/Users/haleynelson/.platformio/packages/framework-arduinoespressif32/tools/sdk/esp32/include/hal/include/hal/adc_types.h:54:5: note: declared here
     ADC_ATTEN_DB_11 __attribute__((deprecated)) = ADC_ATTEN_DB_12,  ///<This is deprecated, it behaves the same as `ADC_ATTEN_DB_12`
     ^~~~~~~~~~~~~~~
```